### PR TITLE
Update curl.c

### DIFF
--- a/jni/curl.c
+++ b/jni/curl.c
@@ -134,6 +134,7 @@ static jmethodID get_method(JNIEnv *env, jobject object, jint option)
 	if (method == NULL) {
 		method = get_method_safely(env, class, "callback", sig);
 	}
+	(*env)->DeleteLocalRef(env, class);
 	return method;
 }
 


### PR DESCRIPTION
Large files (with or without xfer progress enabled) throw a native error "JNI ERROR (app bug): local reference table overflow (max=512)"

A simple cleanup in the method 'get_method' to delete a local reference seems to fix the problem.
